### PR TITLE
Clarify confusion about Caddyfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ caddy -service install [-name optionalServiceName] [-option optionValue]
 ```
 
 Notes:
-1. You **must** set the `-conf` flag to your Caddyfile.
+1. You **must** set the `-conf` flag to your Caddyfile. Though, usually Caddy works by using the caddyfile in the directory which the caddy executable resides in, which is not necessarily the working directory. However, the service does not load the Caddyfile from the executable directory, and so must be specified using the `-conf` flag.
 2. Notice that if you install the service with a name that is not the default's, you will need to specify it everytime you use one of the other commands using the flag `-name`.
 3. You can install the service with default Caddy flag values (e.g. -conf MyCaddyfile)
 


### PR DESCRIPTION
The current README doesn't clarify, IMO, sufficiently for the newbies that it's necessary to use the `conf` flag to explicitly mention `Caddyfile`, causing confusion like #4 

So, I propose to add more details regarding this. Please, feel free to edit furthermore to make the edit better as I am not a native speaker.