### PR TITLE
Update install steps to include required args

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ caddy -service install -agree -email myemail@email.com -conf /path/to/Caddyfile 
 Notes:
 1. You **must** set the `-conf` flag to your Caddyfile. Though, usually Caddy works by using the caddyfile in the directory which the caddy executable resides in, which is not necessarily the working directory. However, the service does not load the Caddyfile from the executable directory, and so must be specified using the `-conf` flag.
 2. You **must** set the `-agree` flag, which says that you have read and agree to the Let's Encrypt Subscriber Agreement. Any type of automated startup requires this flag.
-3. You **must** set the `-email` flag to your email address if not specified for a site in the CaddyFile. This email address will be used for TLS certificate generation.
+3. You **must** set the `-email` flag to your email address if not specified for a site in the Caddyfile. This email address will be used for TLS certificate generation.
 4. Notice that if you install the service with a name that is not the default's, you will need to specify it everytime you use one of the other commands using the flag `-name`.
 5. You can install the service with default Caddy flag values (e.g. -conf MyCaddyfile)
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ Right now, this plugin seems to work well on most systems that kardianos/service
 ### Install a Caddy service:
 
 ```
-caddy -service install -conf /path/to/Caddyfile [-name optionalServiceName] [-option optionValue]
+caddy -service install -agree -email myemail@email.com -conf /path/to/Caddyfile [-name optionalServiceName] [-option optionValue]
 ```
 
 Notes:
 1. You **must** set the `-conf` flag to your Caddyfile. Though, usually Caddy works by using the caddyfile in the directory which the caddy executable resides in, which is not necessarily the working directory. However, the service does not load the Caddyfile from the executable directory, and so must be specified using the `-conf` flag.
-2. Notice that if you install the service with a name that is not the default's, you will need to specify it everytime you use one of the other commands using the flag `-name`.
-3. You can install the service with default Caddy flag values (e.g. -conf MyCaddyfile)
+2. You **must** set the `-agree` flag, which says that you have read and agree to the Let's Encrypt Subscriber Agreement. Any type of automated startup requires this flag.
+3. You **must** set the `-email` flag to your email address if not specified for a site in the CaddyFile. This email address will be used for TLS certificate generation.
+4. Notice that if you install the service with a name that is not the default's, you will need to specify it everytime you use one of the other commands using the flag `-name`.
+5. You can install the service with default Caddy flag values (e.g. -conf MyCaddyfile)
 
 
 


### PR DESCRIPTION
Added new steps to the install instructions to include required args.
Without these args, the install succeeds but the service will fail to
start.

* `-agree`, required for the Let's Encrypt certification
* `-email`, docs says optional but service would not start without it.

This post on the Caddy forum helped direct me to the solution:

https://caddy.community/t/caddy-unable-to-start-as-a-service-on-window-server-2008-r2/3646/37